### PR TITLE
Add tests for collect_unicast_peers

### DIFF
--- a/manifests/vrrp/unicast_peer.pp
+++ b/manifests/vrrp/unicast_peer.pp
@@ -2,23 +2,22 @@
 #
 # === Parameters:
 #
-# $name::     IP address of unicast peer
-# $instance:: Name of vrrp instance this peer belongs to
+# $instance::   Name of vrrp instance this peer belongs to
+#
+# $ip_address:: IP address of unicast peer
+#               Default: $name
 #
 define keepalived::vrrp::unicast_peer (
-  $instance,
+  String $instance,
+  Stdlib::IP::Address $ip_address = $name,
 ) {
   assert_private()
 
   $_inst = regsubst($instance, '[:\/\n]', '')
 
-  validate_ip_address($name)
-
-  if ! has_ip_address($name) {
-    concat::fragment { "keepalived.conf_vrrp_instance_${_inst}_upeers_peer_${name}":
-      target  => "${keepalived::config_dir}/keepalived.conf",
-      content => "    ${title}\n",
-      order   => "100-${_inst}-010",
-    }
+  concat::fragment { "keepalived.conf_vrrp_instance_${_inst}_upeers_peer_${ip_address}":
+    target  => "${keepalived::config_dir}/keepalived.conf",
+    content => "    ${ip_address}\n",
+    order   => "100-${_inst}-020",
   }
 }

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -897,7 +897,7 @@ describe 'keepalived::vrrp::instance', type: :define do
       describe 'with parameter unicast_source_ip' do
         let(:params) do
           mandatory_params.merge(
-            unicast_source_ip: '_VALUE_'
+            unicast_source_ip: '10.1.2.3'
           )
         end
 
@@ -905,7 +905,7 @@ describe 'keepalived::vrrp::instance', type: :define do
         it {
           is_expected.to \
             contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
-              'content' => %r{unicast_src_ip.*_VALUE_}
+              'content' => %r{unicast_src_ip.*10\.1\.2\.3}
             )
         }
       end
@@ -936,12 +936,53 @@ describe 'keepalived::vrrp::instance', type: :define do
         it { is_expected.to create_keepalived__vrrp__instance('_NAME_') }
         it {
           is_expected.to \
-            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
-              'content' => %r{10.0.1.0}
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_header').with(
+              'content' => "  unicast_peer {\n"
             )
           is_expected.to \
-            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
-              'content' => %r{10.0.2.0}
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_peer_10.0.1.0').with(
+              'content' => "    10.0.1.0\n"
+            )
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_peer_10.0.2.0').with(
+              'content' => "    10.0.2.0\n"
+            )
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_footer').with(
+              'content' => "  }\n\n"
+            )
+          is_expected.to \
+            contain_keepalived__vrrp__unicast_peer('10.0.1.0').with(
+              'instance' => '_NAME_'
+            )
+          is_expected.to \
+            contain_keepalived__vrrp__unicast_peer('10.0.2.0').with(
+              'instance' => '_NAME_'
+            )
+        }
+      end
+
+      describe 'with collect_unicast_peers set to true' do
+        let(:params) do
+          mandatory_params.merge(
+            collect_unicast_peers: true,
+            unicast_source_ip: '10.0.3.0'
+          )
+        end
+
+        it { is_expected.to create_keepalived__vrrp__instance('_NAME_') }
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_header').with(
+              'content' => "  unicast_peer {\n"
+            )
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_footer').with(
+              'content' => "  }\n\n"
+            )
+          expect(exported_resources).to \
+            contain_keepalived__vrrp__unicast_peer('10.0.3.0').with(
+              'instance' => '_NAME_'
             )
         }
       end


### PR DESCRIPTION
I also replaced a lot of explicit type validation by specifying types at
init, as recommended by bastelfreak. The unicast_source_ip parameter
previously was not required to be a valid IP address, so this broke an
existing test that was setting it to `_VALUE_`.

I also modified the test around setting explicit unicast_peers, since
this feature replaces a single concat fragment with several.